### PR TITLE
fixed lack of send_to_self in JSON files

### DIFF
--- a/json/foldedclos_iq_stresstest.json
+++ b/json/foldedclos_iq_stresstest.json
@@ -86,7 +86,8 @@
       "warmup_window": 15,
       "warmup_attempts": 20,
       "traffic_pattern": {
-        "type": "uniform_random"
+        "type": "uniform_random",
+        "send_to_self": false
       }
     },
     "message_log": {

--- a/json/hyperx_iq_stresstest.json
+++ b/json/hyperx_iq_stresstest.json
@@ -87,7 +87,8 @@
       "warmup_window": 15,
       "warmup_attempts": 50,
       "traffic_pattern": {
-        "type": "uniform_random"
+        "type": "uniform_random",
+        "send_to_self": false
       }
     },
     "message_log": {

--- a/json/torus_iq_stresstest.json
+++ b/json/torus_iq_stresstest.json
@@ -85,7 +85,8 @@
       "warmup_window": 15,
       "warmup_attempts": 20,
       "traffic_pattern": {
-        "type": "uniform_random"
+        "type": "uniform_random",
+        "send_to_self": false
       }
     },
     "message_log": {

--- a/json/uno_ioq_stresstest.json
+++ b/json/uno_ioq_stresstest.json
@@ -96,7 +96,8 @@
       "warmup_window": 15,
       "warmup_attempts": 20,
       "traffic_pattern": {
-        "type": "uniform_random"
+        "type": "uniform_random",
+        "send_to_self": false
       }
     },
     "message_log": {

--- a/json/uno_iq_stresstest.json
+++ b/json/uno_iq_stresstest.json
@@ -82,7 +82,8 @@
       "warmup_window": 15,
       "warmup_attempts": 20,
       "traffic_pattern": {
-        "type": "uniform_random"
+        "type": "uniform_random",
+        "send_to_self": false
       }
     },
     "message_log": {


### PR DESCRIPTION
The new features of traffic patterns didn't have the proper "send_to_self" attribute in the JSON files for the alternating traffic patterns. This now exists and json/run_all.py will run with success.
